### PR TITLE
Replacing "src/bmi_aorc.c" with its latest version

### DIFF
--- a/src/aorc.c
+++ b/src/aorc.c
@@ -71,7 +71,7 @@ extern int run_aorc(aorc_model* model)
   aorc_calculate_solar_radiation(model);
   
   if (model->bmi.verbose > 1)
-    printf("calculate the net radiation");
+    printf("calculate the net radiation\n");
     // NOTE don't call this function use_aerodynamic_method option is TRUE
   model->other_forcing.net_radiation_W_per_sq_m=aorc_calculate_net_radiation_W_per_sq_m(model);
 
@@ -148,79 +148,67 @@ void aorc_unit_tests(aorc_model* model)
 /*####################################################################*/
 /*########################### PARSE LINE #############################*/
 /*####################################################################*/
-void parse_aorc_line_aorc(char *theString, long *year, long *month, long *day, long *hour, long *minute, double *second,
-                     struct aorc_forcing_data *aorc) {
-    char str[20];
-    long yr, mo, da, hr, mi;
-    double mm, julian, se;
-    double val;
-    int i, start, end, len;
-    int yes_pm, wordlen;
+void parse_aorc_line_aorc(char *theString,long *year,long *month, long *day,long *hour,long *minute, double *second,
+                struct aorc_forcing_data *aorc)
+{
+    int start,end;
+    int wordlen;
     char theWord[150];
+    
+    //len=strlen(theString);
+    
+    start=0; /* begin at the beginning of theString */
+    get_word_aorc(theString,&start,&end,theWord,&wordlen);
+    *year=atol(theWord);
+    
+    get_word_aorc(theString,&start,&end,theWord,&wordlen);
+    *month=atol(theWord);
+    
+    get_word_aorc(theString,&start,&end,theWord,&wordlen);
+    *day=atol(theWord);
+    
+    get_word_aorc(theString,&start,&end,theWord,&wordlen);
+    *hour=atol(theWord);
+    
+    get_word_aorc(theString,&start,&end,theWord,&wordlen);
+    *minute=atol(theWord);
+    
+    get_word_aorc(theString,&start,&end,theWord,&wordlen);
+    *second=(double)atof(theWord);
+    
+    get_word_aorc(theString,&start,&end,theWord,&wordlen);
+    aorc->precip_kg_per_m2=atof(theWord);
+    //printf("%s, %s, %lf, %lf\n", theString, theWord, (double)atof(theWord), aorc->precip_kg_per_m2);
+                  
+    get_word_aorc(theString,&start,&end,theWord,&wordlen);
+    aorc->incoming_longwave_W_per_m2=(double)atof(theWord);   
+    
+    get_word_aorc(theString,&start,&end,theWord,&wordlen);
+    aorc->incoming_shortwave_W_per_m2=(double)atof(theWord);   
+    
+    get_word_aorc(theString,&start,&end,theWord,&wordlen);
+    aorc->surface_pressure_Pa=(double)atof(theWord);           
+    
+    get_word_aorc(theString,&start,&end,theWord,&wordlen);
+    aorc->specific_humidity_2m_kg_per_kg=(double)atof(theWord);
+    
+    get_word_aorc(theString,&start,&end,theWord,&wordlen);
+    aorc->air_temperature_2m_K=(double)atof(theWord);          
+    
+    get_word_aorc(theString,&start,&end,theWord,&wordlen);
+    aorc->u_wind_speed_10m_m_per_s=(double)atof(theWord);      
+    
+    get_word_aorc(theString,&start,&end,theWord,&wordlen);
+    aorc->v_wind_speed_10m_m_per_s=(double)atof(theWord);      
 
-    len = strlen(theString);
-
-    char *copy, *copy_to_free, *value;
-    copy_to_free = copy = strdup(theString);
-
-    // time
-    value = strsep(&copy, ",");
-    // TODO: handle this
-    // struct tm{
-    //   int tm_year;
-    //   int tm_mon; 
-    //   int tm_mday; 
-    //   int tm_hour; 
-    //   int tm_min; 
-    //   int tm_sec; 
-    //   int tm_isdst;
-    // } t;
-    struct tm t;
-    time_t t_of_day;
-
-    t.tm_year = (int)strtol(strsep(&value, "-"), NULL, 10) - 1900;
-    t.tm_mon = (int)strtol(strsep(&value, "-"), NULL, 10);
-    t.tm_mday = (int)strtol(strsep(&value, " "), NULL, 10);
-    t.tm_hour = (int)strtol(strsep(&value, ":"), NULL, 10);
-    t.tm_min = (int)strtol(strsep(&value, ":"), NULL, 10);
-    t.tm_sec = (int)strtol(value, NULL, 10);
-    t.tm_isdst = -1;        // Is DST on? 1 = yes, 0 = no, -1 = unknown
-    aorc->time = mktime(&t);
-
-    // APCP_surface
-    value = strsep(&copy, ",");
-    // Not sure what this is
-
-    // DLWRF_surface
-    value = strsep(&copy, ",");
-    aorc->incoming_longwave_W_per_m2 = strtof(value, NULL);
-    // DSWRF_surface
-    value = strsep(&copy, ",");
-    aorc->incoming_shortwave_W_per_m2 = strtof(value, NULL);
-    // PRES_surface
-    value = strsep(&copy, ",");
-    aorc->surface_pressure_Pa = strtof(value, NULL);
-    // SPFH_2maboveground
-    value = strsep(&copy, ",");
-    aorc->specific_humidity_2m_kg_per_kg = strtof(value, NULL);;
-    // TMP_2maboveground
-    value = strsep(&copy, ",");
-    aorc->air_temperature_2m_K = strtof(value, NULL);
-    // UGRD_10maboveground
-    value = strsep(&copy, ",");
-    aorc->u_wind_speed_10m_m_per_s = strtof(value, NULL);
-    // VGRD_10maboveground
-    value = strsep(&copy, ",");
-    aorc->v_wind_speed_10m_m_per_s = strtof(value, NULL);
-    // precip_rate
-    value = strsep(&copy, ",");
-    aorc->precip_kg_per_m2 = strtof(value, NULL);
-
-    // Go ahead and free the duplicate copy now
-    free(copy_to_free);
-
+    //----------------------------------------------    
+    // Is this needed?  It has not been set. (SDP)
+    //----------------------------------------------
+    aorc->time = -9999.0;
+    //######################################################
+     
     return;
-}
+    }
 
 /*####################################################################*/
 /*############################## GET WORD ############################*/
@@ -269,7 +257,7 @@ void itwo_alloc_aorc(int ***array, int rows, int cols) {
 
     if ((rows == 0) || (cols == 0)) {
         printf("Error: Attempting to allocate array of size 0\n");
-        exit;
+        exit(-9);
     }
 
     frows = rows + 1;  /* added one for FORTRAN numbering */
@@ -298,7 +286,7 @@ void dtwo_alloc_aorc(double ***array, int rows, int cols) {
 
     if ((rows == 0) || (cols == 0)) {
         printf("Error: Attempting to allocate array of size 0\n");
-        exit;
+        exit(-9);
     }
 
     frows = rows + 1;  /* added one for FORTRAN numbering */

--- a/src/bmi_aorc.c
+++ b/src/bmi_aorc.c
@@ -66,13 +66,13 @@ Initialize (Bmi *self, const char *cfg_file)
     fgets(line_str, max_forcing_line_length + 1, ffp);
 
     if (aorc->bmi.verbose > 2) 
-        printf("the number of time steps from the forcing file is: %8.6e \n", aorc->bmi.num_timesteps);
+        printf("the number of time steps from the forcing file is: %8.6ld \n", aorc->bmi.num_timesteps);
 
     aorc_forcing_data forcings;
     for (int i = 0; i < aorc->bmi.num_timesteps; i++) {
         fgets(line_str, max_forcing_line_length + 1, ffp);  // read in a line of AORC data.
         parse_aorc_line_aorc(line_str, &year, &month, &day, &hour, &minute, &dsec, &forcings);
-        aorc->forcing_data_precip_kg_per_m2[i] = forcings.precip_kg_per_m2 * ((double)aorc->bmi.time_step_size);
+        aorc->forcing_data_precip_kg_per_m2[i] = forcings.precip_kg_per_m2; //jmframe   * ((double)aorc->bmi.time_step_size);
         if (aorc->bmi.verbose >4)
             printf("precip %f \n", aorc->forcing_data_precip_kg_per_m2[i]);
         aorc->forcing_data_surface_pressure_Pa[i] = forcings.surface_pressure_Pa;
@@ -138,7 +138,7 @@ Update_until(Bmi *self, double t)
     // relative number of time steps into the future, or invalid
 
     if (aorc->bmi.verbose >= 1)
-        printf("running update until time %lld \n", t);
+        printf("running update until time %f \n", t);
 
     // Don't support negative parameter values
     if (t < 0.0)
@@ -163,7 +163,7 @@ Update_until(Bmi *self, double t)
 
     // jmframe troubleshooting. Please delete this printout
     if (aorc->bmi.verbose > 3){
-        printf("end time %8.6e, please delete this printout\n", &end_time);
+        printf("end time %8.6e, please delete this printout\n", end_time);
         printf("the current time is %8.6e \n", current_time);
         printf("the end time result is %d \n", end_time_result);
     }
@@ -171,7 +171,7 @@ Update_until(Bmi *self, double t)
     if (end_time_result == BMI_FAILURE || current_time >= end_time){
         printf("BMI Failued due to end_time_result OR current time greater than end time \n");
         if (end_time_result == BMI_FAILURE)
-            printf("end_time_result failed %s \n");
+            printf("end_time_result failed\n");
         if (current_time >= end_time)
             printf("current_time %8.6e is greater than end time %8.6e \n", current_time, end_time);
         return BMI_FAILURE;
@@ -217,7 +217,7 @@ Update_until(Bmi *self, double t)
             // jmframe troubleshooting. Please delete
             if (aorc->bmi.verbose > 3){
                 printf("current time step %f \n", aorc->bmi.current_time_step);
-                printf("current step %f \n", aorc->bmi.current_step);
+                printf("current step %ld \n", aorc->bmi.current_step);
                 printf("current time %f \n", aorc->bmi.current_time);
             }
 
@@ -441,7 +441,7 @@ static int Get_current_time (Bmi *self, double * time)
 {
     Get_start_time(self, time);
     if (((aorc_model *) self->data)->bmi.verbose > 2){
-        printf("Current model time step: '%ld'\n", ((aorc_model *) self->data)->bmi.current_time_step);
+        printf("Current model time step: '%f'\n", ((aorc_model *) self->data)->bmi.current_time_step);
     }
     *time += (((aorc_model *) self->data)->bmi.current_step * 
               ((aorc_model *) self->data)->bmi.time_step_size);
@@ -654,7 +654,7 @@ int read_init_config_aorc(aorc_model* model, const char* config_file)//,
             model->bmi.num_timesteps = strtod(param_value, NULL);
             if(model->bmi.verbose >=2){
                 printf("num_timesteps from config file \n");
-                printf("%d\n", model->bmi.num_timesteps);
+                printf("%ld\n", model->bmi.num_timesteps);
             }
             continue;
         }


### PR DESCRIPTION
During our CFE standalone review, Ahmad found that the `bmi_aorc.c` file in the aorc_bmi repo wasn't the latest version, this PR is for updating it. Since the old version `bmi_aorc.c` file was originally copied from the `PET/forcing_code`, this update has also been tested with the PET standalone `make_and_run_pass_forcings.sh`.

## Additions

-None

## Removals

-None

## Changes

-`src/bmi_aorc.c` (now it's same as the `cfe/forcing_code/src/bmi_aorc.c`, with path `#include "../../include/bmi.h"` modified to `#include "../include/bmi.h"`)

## Testing

1. Tested with cfe standalone option FORCING and option FORCINGPET
2. Tested with pet standalone ./make_and_run_pass_forcings.sh

## Screenshots


## Notes

-

## Todos

-

## Checklist

- [x ] PR has an informative and human-readable title
- [x ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows project standards (link if applicable)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Target Environment support

- [ ] Windows
- [x ] Linux
- [ ] Browser

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
